### PR TITLE
fix: Use Debian based Docker images

### DIFF
--- a/9000/jdk/11-jdk/Dockerfile
+++ b/9000/jdk/11-jdk/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /opt/jruby/etc \
     } >> /opt/jruby/etc/gemrc
 
 # install bundler, gem requires bash to work
-RUN gem install bundler rake net-telnet xmlrpc
+RUN gem install bundler rake net-telnet xmlrpc tzinfo-data
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps

--- a/9000/jdk/12-jdk/Dockerfile
+++ b/9000/jdk/12-jdk/Dockerfile
@@ -1,4 +1,8 @@
-FROM openjdk:12-jdk
+FROM adoptopenjdk:12-jdk-openj9
+
+RUN apt-get update \
+    && apt-get install -y libc6-dev git tcc --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.2.7.0
 ENV JRUBY_SHA256 da7c1a5ce90015c0bafd4bca0352294e08fe1c9ec049ac51e82fe57ed50e1348

--- a/9000/jdk/12-jdk/Dockerfile
+++ b/9000/jdk/12-jdk/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /opt/jruby/etc \
     } >> /opt/jruby/etc/gemrc
 
 # install bundler, gem requires bash to work
-RUN gem install bundler rake net-telnet xmlrpc
+RUN gem install bundler rake net-telnet xmlrpc tzinfo-data
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps

--- a/9000/jdk/12-jdk/Dockerfile
+++ b/9000/jdk/12-jdk/Dockerfile
@@ -1,7 +1,7 @@
 FROM adoptopenjdk:12-jdk-openj9
 
 RUN apt-get update \
-    && apt-get install -y libc6-dev git tcc --no-install-recommends \
+    && apt-get install -y libc6-dev git tcc netbase --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.2.7.0

--- a/9000/jdk/13-jdk/Dockerfile
+++ b/9000/jdk/13-jdk/Dockerfile
@@ -1,4 +1,8 @@
-FROM openjdk:13-jdk
+FROM openjdk:13-jdk-slim
+
+RUN apt-get update \
+    && apt-get install -y libc6-dev git tcc curl --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.2.7.0
 ENV JRUBY_SHA256 da7c1a5ce90015c0bafd4bca0352294e08fe1c9ec049ac51e82fe57ed50e1348

--- a/9000/jdk/13-jdk/Dockerfile
+++ b/9000/jdk/13-jdk/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:13-jdk-slim
 
 RUN apt-get update \
-    && apt-get install -y libc6-dev git tcc curl --no-install-recommends \
+    && apt-get install -y libc6-dev git tcc curl netbase --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.2.7.0

--- a/9000/jdk/13-jdk/Dockerfile
+++ b/9000/jdk/13-jdk/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /opt/jruby/etc \
     } >> /opt/jruby/etc/gemrc
 
 # install bundler, gem requires bash to work
-RUN gem install bundler rake net-telnet xmlrpc
+RUN gem install bundler rake net-telnet xmlrpc tzinfo-data
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps

--- a/9000/jdk/7-jdk/Dockerfile
+++ b/9000/jdk/7-jdk/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /opt/jruby/etc \
     } >> /opt/jruby/etc/gemrc
 
 # install bundler, gem requires bash to work
-RUN gem install bundler rake net-telnet xmlrpc
+RUN gem install bundler rake net-telnet xmlrpc tzinfo-data
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps

--- a/9000/jdk/8-jdk/Dockerfile
+++ b/9000/jdk/8-jdk/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /opt/jruby/etc \
     } >> /opt/jruby/etc/gemrc
 
 # install bundler, gem requires bash to work
-RUN gem install bundler rake net-telnet xmlrpc
+RUN gem install bundler rake net-telnet xmlrpc tzinfo-data
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps


### PR DESCRIPTION
## What does this PR do?

When Java 12 was released seems like there was an issue with the Debian based Docker images, because of that there is not Debian based Docker image for OpenJDK on Java 12, OpenJDK switch to OracleLinux, this distribution is a RedHat based distribution and the package system changes. Seems like on Java 13 OpenJDK reconsidered this decision and they release `openjdk:*-jdk-slim` based on Debian. So for Java 12, we would use an AdoptOpenJDK Docker image based on Debian. The community is moving to AdoptOpenJDK for this and other reasons, we should think about it too.

https://stackoverflow.com/questions/52431764/difference-between-openjdk-and-adoptopenjdk

## Why is it important?

The images before this change do not have a `cc` compiler that it is need to build the `html-parser` gem from source, thus we install `libc6-dev` and a tiny C compiler `tcc`

